### PR TITLE
Mapped 'URL national rules'

### DIFF
--- a/output/mapping/F21_2014.csv
+++ b/output/mapping/F21_2014.csv
@@ -95,7 +95,7 @@ xpath,label-key,index,comment,guidance
 /PROCEDURE/PT_AWARD_CONTRACT_WITHOUT_CALL,award_wo_prior_pub_d1,,,"Set `tender.procurementMethod` to 'limited', and set `tender.procurementMethodDetails` to 'Award procedure without prior publication of a call for competition'.\n\n**F03, F21:** See [Annex D1](#annex-d1-general-procurement)\n\n**F06, F22:** See [Annex D2](#annex-d2-utilities)"
 /PROCEDURE/FRAMEWORK,notice_involves_framework,,,Set `tender.techniques.hasFrameworkAgreement` to `true`
 /PROCEDURE/FRAMEWORK/JUSTIFICATION,framework_just_four,,,Map to `tender.techniques.frameworkAgreement.periodRationale`
-/PROCEDURE/URL_NATIONAL_PROCEDURE,url_national_rules,,,
+/PROCEDURE/URL_NATIONAL_PROCEDURE,url_national_rules,,,"Map to `tender.procedure.features`."
 /PROCEDURE/MAIN_FEATURES_AWARD,award_main_features,IV.1.11,,Map to `tender.awardCriteriaDetails`
 /PROCEDURE/NOTICE_NUMBER_OJ,number_oj,,https://github.com/open-contracting-archive/trade/tree/master/draft_extensions/release_relatedNotice,[Reference a previous publication](../operations#reference-a-previous-publication)
 /PROCEDURE/DATE_RECEIPT_TENDERS,date,,,Map to the date component of `tender.tenderPeriod.endDate`


### PR DESCRIPTION
I've mapped it to `tender.procedure.features`, following eForms structure (BT-88).

