### PR TITLE
Instructions to install requirements for the missing extensions script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,12 @@ You can now generate a table for each form, displaying, for each element and att
 
 ### Find fields for which to write extensions
 
+You need `ocdskit` and `ocdsextensionregistry` Python modules. You can install them both using pip:
+
+```
+pip install ocdskit
+```
+
 Generate a release schema with all extensions applied, except the PPP extension (which removes fields):
 
     python scripts/patched_release_schema.py > scripts/release-schema-patched.json


### PR DESCRIPTION
Giving standard instructions to install Python modules is always tricky. In my case, for instance, I must use `pip3` and the `--user` parameter.

I wanted to add this as a reminder, as I got a new laptop and started from a clean system and didn't understant why the missing extension script didn't work.