### PR TITLE
Mapping of CHANGES that mirrors TED structure

### DIFF
--- a/output/content/F14.md
+++ b/output/content/F14.md
@@ -16,27 +16,3 @@ If you have already implemented all prior forms, this notice adds:
 
 * [VI.6](#VI.6) Original notice reference
 * [VII](#VII) Changes
-
-## Guidance for `/CHANGES/CHANGE`
-
-The XML elements for Section VII don't map directly to OCDS fields. They require step-by-step instructions instead of field-by-field guidance.
-
-1. Download "Form labels R2.0.9 (zip)" from [TED schemas](https://op.europa.eu/en/web/eu-vocabularies/e-procurement/tedschemas)
-
-### Using the OCDS HTML mapping tables
-
-1. If the form is not in English, use the Form labels spreadsheet above to look up the **English label** for the value in `/CHANGES/CHANGE/WHERE/LABEL` (*Place of text to be modified*). The value in `/@LG` (the language of the form) is the column in which to search for this value. The "EN" column in the same row as the matching cell contains the English label.
-1. Search this documentation website for the English label to find the OCDS guidance. Use the value in `/CHANGES/CHANGE/WHERE/SECTION` (*Section number*) to disambiguate, if there are multiple mappings for the English label.
-1. If the label has no guidance, use the guidance in the rows that follow. For example, for *Estimated total value*, use the guidance for *Value excluding VAT* and *Currency*.
-1. If the OCDS guidance pertains to a lot, find the `Lot` object in `tender.lots` whose `.id` string-matches the value in `/CHANGES/CHANGE/WHERE/LOT_NO` (*Lot No*). Then, follow the guidance as usual.
-
-### Using the OCDS CSV mapping files
-
-1. If the form is not in English, use the Form labels spreadsheet above to look up the **label key** for the value in `/CHANGES/CHANGE/WHERE/LABEL` (*Place of text to be modified*). The value in `/@LG` (the language of the form) is the column in which to search for this value. The "Label" column in the same row as the matching cell contains the label key.
-2. Search the [OCDS CSV mapping files](https://github.com/open-contracting/european-union-support/tree/master/output/mapping) for the label key. Use the value in `/CHANGES/CHANGE/WHERE/SECTION` (*Section number*) to disambiguate, if there are multiple mappings for the label key.
-1. If the label key has no guidance, use the guidance in the rows that follow. For example, for `value_magnitude_estimated_total`, use the guidance for `value_excl_vat` and `currency`.
-1. If the OCDS guidance pertains to a lot, find the `Lot` object in `tender.lots` whose `.id` string-matches the value in `/CHANGES/CHANGE/WHERE/LOT_NO` (*Lot No*). Then, follow the guidance as usual.
-
-### Guidance for `/CHANGES/CHANGE/NEW_VALUE`
-
-* If `/CHANGES/CHANGE/NEW_VALUE/NOTHING` is set, treat it as a `null` or empty value

--- a/output/mapping/F14_2014.csv
+++ b/output/mapping/F14_2014.csv
@@ -49,7 +49,7 @@ xpath,label-key,index,comment,guidance
 /CHANGES/CHANGE/WHERE/SECTION,section_no,,,Map to `.where.section`
 /CHANGES/CHANGE/OLD_VALUE,icar_instead,,,""
 /CHANGES/CHANGE/NEW_VALUE,icar_read,,,""
-/CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,Map to `.where.lot`
+/CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,Map to `.relatedLot`
 /CHANGES/CHANGE/WHERE/LABEL,icar_text_corr_place,,,Map to `.where.label`
 /CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,Set `.oldValue.text` to ''
 /CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,Set `.newValue.text` to ''
@@ -57,18 +57,18 @@ xpath,label-key,index,comment,guidance
 /CHANGES/CHANGE/NEW_VALUE/TEXT,,,,Map to `.newValue.text`
 /CHANGES/CHANGE/OLD_VALUE/CPV_MAIN,,,,""
 /CHANGES/CHANGE/NEW_VALUE/CPV_MAIN,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,Map to `.oldValue.mainCpv`
-/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,Map to `.newValue.mainCpv`
-/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,Map to `.oldValue.mainCpvSupplementary`
-/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,Map to `.newValue.mainCpvSupplementary`
+/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,"Add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
+/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,"Add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
+/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,"For each `CODE` attribute, add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `oldValue.classifications` array."
+/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,"For each `CODE` attribute, add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `newValue.classifications` array"
 /CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,Map to `.oldValue.additionalCpv`
-/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,Map to `.oldValue.additionalCpvSupplementary`
+/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,"Add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
+/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `oldValue.classifications` array"
 /CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL,,,,""
-/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,Map to `.newValue.additionalCpv`
-/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,Map to `.newValue.additionalCpvSupplementary`
-/CHANGES/CHANGE/OLD_VALUE/DATE,date,,,Map to `.oldValue.date`
-/CHANGES/CHANGE/NEW_VALUE/DATE,date,,,Map to `.newValue.date`
-/CHANGES/CHANGE/OLD_VALUE/TIME,time,,,Map to `.oldValue.time`
-/CHANGES/CHANGE/NEW_VALUE/TIME,time,,,Map to `.newValue.time`
+/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,"Add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
+/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `newValue.classifications` array"
+/CHANGES/CHANGE/OLD_VALUE/DATE,date,,,Map to the date component of `oldValue.datetime`    `
+/CHANGES/CHANGE/NEW_VALUE/DATE,date,,,Map to the date component of `newValue.datetime`
+/CHANGES/CHANGE/OLD_VALUE/TIME,time,,,Map to the time component of `oldValue.datetime`
+/CHANGES/CHANGE/NEW_VALUE/TIME,time,,,Map to the time component of `newValue.datetime`
 /CHANGES/INFO_ADD,icar_other_info,VII.2,,Map to the amendment's `.description`

--- a/output/mapping/F14_2014.csv
+++ b/output/mapping/F14_2014.csv
@@ -51,24 +51,24 @@ xpath,label-key,index,comment,guidance
 /CHANGES/CHANGE/NEW_VALUE,icar_read,,,""
 /CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,Map to `.relatedLot`
 /CHANGES/CHANGE/WHERE/LABEL,icar_text_corr_place,,,Map to `.where.label`
-/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,Set `.oldValue.text` to ''
-/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,Set `.newValue.text` to ''
+/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,"Set `.oldValue.text` to """" (an empty string)"
+/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,"Set `.newValue.text` to """" (an empty string)"
 /CHANGES/CHANGE/OLD_VALUE/TEXT,,,,Map to `.oldValue.text`
 /CHANGES/CHANGE/NEW_VALUE/TEXT,,,,Map to `.newValue.text`
 /CHANGES/CHANGE/OLD_VALUE/CPV_MAIN,,,,""
 /CHANGES/CHANGE/NEW_VALUE/CPV_MAIN,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,"Add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
-/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,"Add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
-/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,"For each `CODE` attribute, add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `oldValue.classifications` array."
-/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,"For each `CODE` attribute, add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `newValue.classifications` array"
+/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,"Add a `Classification` object to the `.oldValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
+/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,"Add a `Classification` object to the `.newValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
+/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,"For each `CODE` attribute, add a `Classification` object to the `.oldValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `.oldValue.classifications` array."
+/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,"For each `CODE` attribute, add a `Classification` object to the `.newValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `.newValue.classifications` array."
 /CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,"Add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
-/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `oldValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `oldValue.classifications` array"
+/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `.oldValue.classifications` array, set its `.scheme` to 'CPV', and map to its `.id`. Remove any duplicate entries from the `.oldValue.classifications` array."
+/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `.oldValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `.oldValue.classifications` array."
 /CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL,,,,""
-/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,"Add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPV', take the CPV code in the `CODE` attribute, and map to its `.id`"
-/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `newValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `newValue.classifications` array"
-/CHANGES/CHANGE/OLD_VALUE/DATE,date,,,Map to the date component of `oldValue.datetime`    `
-/CHANGES/CHANGE/NEW_VALUE/DATE,date,,,Map to the date component of `newValue.datetime`
-/CHANGES/CHANGE/OLD_VALUE/TIME,time,,,Map to the time component of `oldValue.datetime`
-/CHANGES/CHANGE/NEW_VALUE/TIME,time,,,Map to the time component of `newValue.datetime`
+/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `.newValue.classifications` array, set its `.scheme` to 'CPV', and map to its `.id`. Remove any duplicate entries from the `.newValue.classifications` array."
+/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,"For each `CODE` attribute, add a `Classification` object to the `.newValue.classifications` array, set its `.scheme` to 'CPVS', prefix by the *Main CPV code*, and map to its `.id`. Remove any duplicate entries from the `.newValue.classifications` array."
+/CHANGES/CHANGE/OLD_VALUE/DATE,date,,,Map to the date component of `.oldValue.date`    `
+/CHANGES/CHANGE/NEW_VALUE/DATE,date,,,Map to the date component of `.newValue.date`
+/CHANGES/CHANGE/OLD_VALUE/TIME,time,,,Map to the time component of `.oldValue.date`
+/CHANGES/CHANGE/NEW_VALUE/TIME,time,,,Map to the time component of `.newValue.date`
 /CHANGES/INFO_ADD,icar_other_info,VII.2,,Map to the amendment's `.description`

--- a/output/mapping/F14_2014.csv
+++ b/output/mapping/F14_2014.csv
@@ -44,31 +44,31 @@ xpath,label-key,index,comment,guidance
 /COMPLEMENTARY_INFO/DATE_DISPATCH_NOTICE,date_dispatch,VI.5,,Map to `date`
 /COMPLEMENTARY_INFO/NOTICE_NUMBER_OJ,number_oj,,https://github.com/open-contracting-archive/trade/tree/master/draft_extensions/release_relatedNotice,[Reference a previous publication](../operations/#reference-a-previous-publication)
 /CHANGES,changes,VII,,"Add an `Amendment` object to the `tender.amendments` array, and set its `.id` (string) sequentially, across all F14 notices for this procedure. (The first notice sets it to '1', the second to '2', etc.)"
-/CHANGES/CHANGE,icar_text_corrected,VII.1.2,,See [Guidance for `/CHANGES/CHANGE`](#guidance-for-changes-change)
+/CHANGES/CHANGE,icar_text_corrected,VII.1.2,,"For each `CHANGE` element, add an `UnstructuredChange` object to the amendment's `.unstructuredChanges` array, and set its `.where`, `.oldValue` and `.newValue` as follows:"
 /CHANGES/CHANGE/WHERE,,,,""
-/CHANGES/CHANGE/WHERE/SECTION,section_no,,,""
+/CHANGES/CHANGE/WHERE/SECTION,section_no,,,Map to `.where.section`.
 /CHANGES/CHANGE/OLD_VALUE,icar_instead,,,""
 /CHANGES/CHANGE/NEW_VALUE,icar_read,,,""
-/CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,""
-/CHANGES/CHANGE/WHERE/LABEL,icar_text_corr_place,,,""
-/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,""
-/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,""
-/CHANGES/CHANGE/OLD_VALUE/TEXT,,,,""
-/CHANGES/CHANGE/NEW_VALUE/TEXT,,,,""
+/CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,Map to `.where.lot`.
+/CHANGES/CHANGE/WHERE/LABEL,icar_text_corr_place,,,Map to `.where.label`.
+/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,Set `.oldValue.text` to `null`.
+/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,Set `.newValue.text` to `null`.
+/CHANGES/CHANGE/OLD_VALUE/TEXT,,,,Map to `.oldValue.text`.
+/CHANGES/CHANGE/NEW_VALUE/TEXT,,,,Map to `.newValue.text`.
 /CHANGES/CHANGE/OLD_VALUE/CPV_MAIN,,,,""
 /CHANGES/CHANGE/NEW_VALUE/CPV_MAIN,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,""
-/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,""
-/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,""
+/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,Map to `.oldValue.mainCpv`.
+/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,Map to `.newValue.mainCpv`
+/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,Map to `.oldValue.mainCpvSupplementary`
+/CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,Map to `.newValue.mainCpvSupplementary`
 /CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,""
+/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,Map to `.oldValue.additionalCpv`
+/CHANGES/CHANGE/OLD_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,Map to `.oldValue.additionalCpvSupplementary`
 /CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL,,,,""
-/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,""
-/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,""
-/CHANGES/CHANGE/OLD_VALUE/DATE,date,,,""
-/CHANGES/CHANGE/NEW_VALUE/DATE,date,,,""
-/CHANGES/CHANGE/OLD_VALUE/TIME,time,,,""
-/CHANGES/CHANGE/NEW_VALUE/TIME,time,,,""
+/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_CODE,,,,Map to `.newValue.additionalCpv`
+/CHANGES/CHANGE/NEW_VALUE/CPV_ADDITIONAL/CPV_SUPPLEMENTARY_CODE,,,,Map to `.newValue.additionalCpvSupplementary`
+/CHANGES/CHANGE/OLD_VALUE/DATE,date,,,Map to `.oldValue.date`
+/CHANGES/CHANGE/NEW_VALUE/DATE,date,,,Map to `.newValue.date`
+/CHANGES/CHANGE/OLD_VALUE/TIME,time,,,Map to `.oldValue.time`
+/CHANGES/CHANGE/NEW_VALUE/TIME,time,,,Map to `.newValue.time`
 /CHANGES/INFO_ADD,icar_other_info,VII.2,,Map to the amendment's `.description`

--- a/output/mapping/F14_2014.csv
+++ b/output/mapping/F14_2014.csv
@@ -51,8 +51,8 @@ xpath,label-key,index,comment,guidance
 /CHANGES/CHANGE/NEW_VALUE,icar_read,,,""
 /CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,Map to `.where.lot`
 /CHANGES/CHANGE/WHERE/LABEL,icar_text_corr_place,,,Map to `.where.label`
-/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,Set `.oldValue.text` to `null`
-/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,Set `.newValue.text` to `null`
+/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,Set `.oldValue.text` to ''
+/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,Set `.newValue.text` to ''
 /CHANGES/CHANGE/OLD_VALUE/TEXT,,,,Map to `.oldValue.text`
 /CHANGES/CHANGE/NEW_VALUE/TEXT,,,,Map to `.newValue.text`
 /CHANGES/CHANGE/OLD_VALUE/CPV_MAIN,,,,""

--- a/output/mapping/F14_2014.csv
+++ b/output/mapping/F14_2014.csv
@@ -46,18 +46,18 @@ xpath,label-key,index,comment,guidance
 /CHANGES,changes,VII,,"Add an `Amendment` object to the `tender.amendments` array, and set its `.id` (string) sequentially, across all F14 notices for this procedure. (The first notice sets it to '1', the second to '2', etc.)"
 /CHANGES/CHANGE,icar_text_corrected,VII.1.2,,"For each `CHANGE` element, add an `UnstructuredChange` object to the amendment's `.unstructuredChanges` array, and set its `.where`, `.oldValue` and `.newValue` as follows:"
 /CHANGES/CHANGE/WHERE,,,,""
-/CHANGES/CHANGE/WHERE/SECTION,section_no,,,Map to `.where.section`.
+/CHANGES/CHANGE/WHERE/SECTION,section_no,,,Map to `.where.section`
 /CHANGES/CHANGE/OLD_VALUE,icar_instead,,,""
 /CHANGES/CHANGE/NEW_VALUE,icar_read,,,""
-/CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,Map to `.where.lot`.
-/CHANGES/CHANGE/WHERE/LABEL,icar_text_corr_place,,,Map to `.where.label`.
-/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,Set `.oldValue.text` to `null`.
-/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,Set `.newValue.text` to `null`.
-/CHANGES/CHANGE/OLD_VALUE/TEXT,,,,Map to `.oldValue.text`.
-/CHANGES/CHANGE/NEW_VALUE/TEXT,,,,Map to `.newValue.text`.
+/CHANGES/CHANGE/WHERE/LOT_NO,lot_number,,,Map to `.where.lot`
+/CHANGES/CHANGE/WHERE/LABEL,icar_text_corr_place,,,Map to `.where.label`
+/CHANGES/CHANGE/OLD_VALUE/NOTHING,,,,Set `.oldValue.text` to `null`
+/CHANGES/CHANGE/NEW_VALUE/NOTHING,,,,Set `.newValue.text` to `null`
+/CHANGES/CHANGE/OLD_VALUE/TEXT,,,,Map to `.oldValue.text`
+/CHANGES/CHANGE/NEW_VALUE/TEXT,,,,Map to `.newValue.text`
 /CHANGES/CHANGE/OLD_VALUE/CPV_MAIN,,,,""
 /CHANGES/CHANGE/NEW_VALUE/CPV_MAIN,,,,""
-/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,Map to `.oldValue.mainCpv`.
+/CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,Map to `.oldValue.mainCpv`
 /CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_CODE,cpv_main,,,Map to `.newValue.mainCpv`
 /CHANGES/CHANGE/OLD_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,Map to `.oldValue.mainCpvSupplementary`
 /CHANGES/CHANGE/NEW_VALUE/CPV_MAIN/CPV_SUPPLEMENTARY_CODE,cpv_supplem,,,Map to `.newValue.mainCpvSupplementary`


### PR DESCRIPTION
I first thought of having only two properties for `.newValue` and `oldValue`:

- `value`: the content
- `type`: text, date, cpv, time, etc

But the CPV fields, with their CPV and supplementary code in the same `CHANGE` (= `.newValue` + `oldValue`), made me change my mind.