### PR TITLE
Added missing dot in `.subcontracting.competitive`

### DIFF
--- a/output/mapping/F15_2014.csv
+++ b/output/mapping/F15_2014.csv
@@ -134,7 +134,7 @@ xpath,label-key,index,comment,guidance
 /AWARD_CONTRACT/AWARDED_CONTRACT/PCT_SUBCONTRACTING,proportion,,,Map to the award's `.subcontracting.minimumPercentage` and `.subcontracting.maximumPercentage`
 /AWARD_CONTRACT/AWARDED_CONTRACT/INFO_ADD_SUBCONTRACTING,subcontr_descr_short,,,Map to the award's `.subcontracting.description`
 /AWARD_CONTRACT/AWARDED_CONTRACT/DIRECTIVE_2009_81_EC,,,,""
-/AWARD_CONTRACT/AWARDED_CONTRACT/DIRECTIVE_2009_81_EC/AWARDED_SUBCONTRACTING,subcontr_all_competitive,,,Set the award's `subcontracting.competitive` to `true`
+/AWARD_CONTRACT/AWARDED_CONTRACT/DIRECTIVE_2009_81_EC/AWARDED_SUBCONTRACTING,subcontr_all_competitive,,,Set the award's `.subcontracting.competitive` to `true`
 /AWARD_CONTRACT/AWARDED_CONTRACT/DIRECTIVE_2009_81_EC/PCT_RANGE_SHARE_SUBCONTRACTING,subcontr_share_competitive,,,""
 /AWARD_CONTRACT/AWARDED_CONTRACT/DIRECTIVE_2009_81_EC/PCT_RANGE_SHARE_SUBCONTRACTING/MIN,min_percentage,,,Map to the award's `.subcontracting.competitiveMinimumPercentage`
 /AWARD_CONTRACT/AWARDED_CONTRACT/DIRECTIVE_2009_81_EC/PCT_RANGE_SHARE_SUBCONTRACTING/MAX,max_percentage,,,Map to the award's `.subcontracting.competitiveMaximumPercentage`


### PR DESCRIPTION
@jpmckinney Simple typo