### PR TITLE
output/content/eforms/operations.md: Add convert a duration to a number of days

### DIFF
--- a/output/content/eforms/operations.md
+++ b/output/content/eforms/operations.md
@@ -43,6 +43,22 @@ Look up the code in the [ISO 639-3 code tables](https://iso639-3.sil.org/code_ta
 
 If the code has no correspondence in ISO 639-1, contact the [OCDS Data Support Team](mailto:data@open-contracting.org).
 
+## Convert a duration to a number of days
+
+If `@unitCode` is 'DAY' or 'CALENDAR_DAY', do nothing.
+
+Otherwise, multiply the duration according to the value of `@unitCode`:
+
+| `@unitCode` | Multiplier |
+| --- | --- |
+| WEEK | 7 |
+| MONTH | 30 |
+| QUARTER | 91 |
+| YEAR_HALF | 182 |
+| YEAR | 365 |
+
+If the value of `@unitCode` does not appear in the above table, contact the [OCDS Data Support Team](mailto:data@open-contracting.org).
+
 ## Add a complaints statistic
 
 Add a `Statistic` object to the `statistics` array, set its `.relatedLot` to the value of `ancestor::efac:LotResult/efac:TenderLot/cbc:ID`, set its `scope` to 'complaints', and set its `.id` (string) sequentially across all notices for this procedure. For example, if a first notice for a given procedure has nine statistics, it uses `id`'s '1' through '9'. A second notice for the same procedure then uses `id`'s '10' and up, etc.

--- a/output/mapping/eforms/guidance.yaml
+++ b/output/mapping/eforms/guidance.yaml
@@ -7675,8 +7675,8 @@
     - TED_EXPORT/FORM_SECTION/F25_2014/OBJECT_CONTRACT/OBJECT_DESCR/DURATION
     eForms guidance: |-
         - [Get the lot for the ProcurementProjectLot](operations.md#get-the-lot-for-a-procurementprojectlot).
-        - If `@unitCode` is "DAY", map to the lot's `.contractPeriod.durationInDays`.
-        - If `@unitCode` is "MONTH", multiply by 30. If `@unitCode` is "YEAR", multiply by 365. In either case, map the result to the lot's `.contractPeriod.durationInDays`.
+        - [Convert the duration to a number of days](operations.md#convert-a-duration-to-a-number-of-days)
+        - Map to the lot's `.contractPeriod.durationInDays`.
     eForms example: <cac:ProcurementProjectLot><cbc:ID schemeName="Lot">LOT-0001</cbc:ID><cac:ProcurementProject><cac:PlannedPeriod><cbc:DurationMeasure unitCode="DAY">3</cbc:DurationMeasure></cac:PlannedPeriod></cac:ProcurementProject></cac:ProcurementProjectLot>
     OCDS example: '{"tender":{"lots":[{"id":"LOT-0001","contractPeriod":{"durationInDays":3}}]}}'
     sdk: https://docs.ted.europa.eu/eforms/latest/schema/procedure-lot-part-information.html#plannedPeriodSection
@@ -7695,9 +7695,8 @@
     - TED_EXPORT/FORM_SECTION/PRIOR_INFORMATION_DEFENCE/FD_PRIOR_INFORMATION_DEFENCE/OBJECT_WORKS_SUPPLIES_SERVICES_PRIOR_INFORMATION/SCHEDULED_DATE_PERIOD/PERIOD_WORK_DATE_STARTING/MONTHS
     - TED_EXPORT/FORM_SECTION/CONTRACT_DEFENCE/FD_CONTRACT_DEFENCE/OBJECT_CONTRACT_INFORMATION_DEFENCE/PERIOD_WORK_DATE_STARTING/(MONTHS|DAYS)
     eForms guidance: |-
-        - If `@unitCode` is "DAY", map to `tender.contractPeriod.durationInDays`.
-        - If `@unitCode` is "MONTH", multiply by 30. If `@unitCode` is "YEAR", multiply by 365. In either case, map the result to `tender.contractPeriod.durationInDays`.
-        - If `@unitCode` is a specific day of the week or month, map an equivalent number of days to `tender.contractPeriod.durationInDays`.
+        - [Convert the duration to a number of days](operations.md#convert-a-duration-to-a-number-of-days)
+        - Map to `tender.contractPeriod.durationInDays`.
     eForms example: <cac:PlannedPeriod><cbc:DurationMeasure unitCode="DAY">3</cbc:DurationMeasure></cac:PlannedPeriod>
     OCDS example: '{"tender":{"contractPeriod":{"durationInDays":3}}}'
     sdk: https://docs.ted.europa.eu/eforms/latest/schema/procedure-lot-part-information.html#plannedPeriodSection


### PR DESCRIPTION
Closes #245

Since BT-36-Part and BT-36-Lot map to different fields in OCDS, I figured it would be easier to put the guidance in `operations.md` and link to it from both fields.

I used Markdown table syntax in `operations.md`, let me know if I should use a different syntax.